### PR TITLE
treeish doesn't exist, use sha instead

### DIFF
--- a/push2docker/lib/push2docker.rb
+++ b/push2docker/lib/push2docker.rb
@@ -96,7 +96,7 @@ module Push2Docker
         clear_var("GIT_DIR") do
           system("git", "clone", "--recursive", Shellwords.escape(url), buildpack_dir,
                  [:out, :err] => "/dev/null") # or raise("Couldn't clone")
-          system("git", "checkout", Shellwords.escape(treeish),
+          system("git", "checkout", Shellwords.escape(sha),
                  [:out, :err] => "/dev/null", :chdir => buildpack_dir) if sha
         end
       end


### PR DESCRIPTION
Pushing an app using a specific branch of a buildpack (separated by #) doesn't work because "treeish" doesn't exist, setting to sha fixes this.
